### PR TITLE
Remove broken link to ROADMAP.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,5 @@ Welcome to the Trust Wallet developer documentation. Here you can find documenta
 * [Assets](assets/add_new_asset.md)
 * [Deep Linking](deeplinking/deeplinking.md)
 * [Staking](platform/staking.md)
-* [Roadmap](roadmap/roadmap.md)
 
 Want to discuss more? join our [Trust Developers chat](https://t.me/trust_developers) on Telegram.


### PR DESCRIPTION
There does not appear to be a valid `ROADMAP.md` file anymore. Let's get rid of that link.