### PR TITLE
Fix page links

### DIFF
--- a/assets/pr-fee.md
+++ b/assets/pr-fee.md
@@ -20,7 +20,7 @@ We were partly insipred by [Token Curated Registry](https://medium.com/@tokencur
 
 **What do I have to pay attention to?**
 
-* Double check the [contribution guidelines](assets/add_new_asset.md), to minimize the risk of your PR being rejected.
+* Double check the [contribution guidelines](assets/new-asset.md), to minimize the risk of your PR being rejected.
 * Make sure to set the correct memo on your transfer.
 
 **How does a Fee fit with Open Source?**

--- a/wallet-core/newblockchain.md
+++ b/wallet-core/newblockchain.md
@@ -4,7 +4,7 @@ If you haven't, first read the [guide to contributing](contributing.md). It cont
 
 ## Blockchains, Coins and Tokens
 
-* If you are interested in adding a new Token, e.g. ERC20, in this case no code changes are needed, see the [Assets](../assets/add_new_asset.md) section for more details. 
+* If you are interested in adding a new Token, e.g. ERC20, in this case no code changes are needed, see the [Assets](../assets/new_asset.md) section for more details. 
 * For new coins you need to implement address handling and signing functionality in wallet-core (described in this section).  For new coins on already supported blockchains, or variations of already supported blockchains, please consider proper reuse of existing implementation.
 
 ## Integration Criteria

--- a/wallet-core/newblockchain.md
+++ b/wallet-core/newblockchain.md
@@ -4,7 +4,7 @@ If you haven't, first read the [guide to contributing](contributing.md). It cont
 
 ## Blockchains, Coins and Tokens
 
-* If you are interested in adding a new Token, e.g. ERC20, in this case no code changes are needed, see the [Assets](../assets/new_asset.md) section for more details. 
+* If you are interested in adding a new Token, e.g. ERC20, in this case no code changes are needed, see the [Assets](../assets/new-asset.md) section for more details. 
 * For new coins you need to implement address handling and signing functionality in wallet-core (described in this section).  For new coins on already supported blockchains, or variations of already supported blockchains, please consider proper reuse of existing implementation.
 
 ## Integration Criteria


### PR DESCRIPTION
Current link to info about adding new assets is broken.
It is specified as `assets/add_new_asset.md`, but there is no such file

![image](https://user-images.githubusercontent.com/2937451/140763336-94a0102f-71f2-47a5-a9c7-4d4fb3bef91f.png)
