### PR TITLE
Wallet-core Coverage: update cmake settings, remove duplicate old description.

### DIFF
--- a/wallet-core/building.md
+++ b/wallet-core/building.md
@@ -167,20 +167,5 @@ Otherwise, the prerequisites have to be installed manually.
 
 ## Unit tests with Coverage
 
-Coverage info can be seen in the GitHub [CI builds](https://codecov.io/gh/trustwallet/wallet-core),
-but can be generated locally as well.
-
-Steps for running unit tests with coverage measurement, and creating report locally:
-
-```bash
-cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON
-make -Cbuild -j12 tests
-find . -name "*.gcda" -exec rm {} \;
-rm -rf coverage.info coverage/
-./build/tests/tests tests --gtest_filter=*
-tools/coverage html
-```
-
-See also 
-[tools/coverage](https://github.com/trustwallet/wallet-core/blob/master/tools/coverage) and
-[linux-ci.yml](https://github.com/trustwallet/wallet-core/blob/master/.github/workflows/linux-ci.yml).
+For executing tests locally with coverage measurement, some extra `cmake` settings are needed;
+see [section on coverage instructions](coverage.md).

--- a/wallet-core/coverage.md
+++ b/wallet-core/coverage.md
@@ -22,10 +22,10 @@ Steps:
 
 - Run `tools/generate-file` to make sure new added files are generated
 
-- Run `cmake`, to enable coverage measurement
+- Run `cmake` with `-DCODE_COVERAGE=ON` to enable coverage measurement
 
 ```shell
-cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON
+cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCODE_COVERAGE=ON
 ```
 
 - Build tests
@@ -56,6 +56,10 @@ c++filt: Unknown command line argument '--no-strip-underscores'.  Try: '/Applica
 c++filt: Did you mean '--no-strip-underscore'?
 genhtml: ERROR: c++filt output not as expected (0 vs 11) lines
 ```
-please patch `genhtml` (for example /usr/local/Cellar/lcov/1.15/libexec/bin/), change `--no-strip-underscores` to `--no-strip-underscore`
+please upgrade `lcov` to min. `1.16`, or patch `genhtml` (for example /usr/local/Cellar/lcov/1.15/libexec/bin/), change `--no-strip-underscores` to `--no-strip-underscore`
 
 Open the generated `coverage/index.html` to view the report.
+
+See also
+[tools/coverage](https://github.com/trustwallet/wallet-core/blob/master/tools/coverage) and
+[linux-ci.yml](https://github.com/trustwallet/wallet-core/blob/master/.github/workflows/linux-ci.yml)


### PR DESCRIPTION
Wallet-core Coverage description:
- extend cmake command with needed compiler flags
- there is two sections on coverage measurement, an older one, and a more detailed newer one.  Removed the old one.
