### PR TITLE
Add developer documentation for EVM chains

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,7 +4,7 @@
 * [Wallet Core](wallet-core/wallet-core.md)
   * [New Blockchain Support](wallet-core/newblockchain.md)
     * [RPC / API Requirements](wallet-core/rpc-requirements.md)
-    * [New EVM Chain](wallet-core/newevmchain.md)
+    * [New EVM-compatible chain](wallet-core/newevmchain.md)
   * Developing the Library
     * [Contributing](wallet-core/contributing.md)
     * [Building](wallet-core/building.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,6 +4,7 @@
 * [Wallet Core](wallet-core/wallet-core.md)
   * [New Blockchain Support](wallet-core/newblockchain.md)
     * [RPC / API Requirements](wallet-core/rpc-requirements.md)
+    * [New EVM Chain](wallet-core/newevmchain.md)
   * Developing the Library
     * [Contributing](wallet-core/contributing.md)
     * [Building](wallet-core/building.md)

--- a/wallet-core/newblockchain.md
+++ b/wallet-core/newblockchain.md
@@ -4,7 +4,8 @@ If you haven't, first read the [guide to contributing](contributing.md). It cont
 
 ## Blockchains, Coins and Tokens
 
-* If you are interested in adding a new Token, e.g. ERC20, in this case no code changes are needed, see the [Assets](../assets/new-asset.md) section for more details. 
+* If you are interested in adding a new Token, e.g. ERC20, in this case no code changes are needed, see the [Assets](../assets/new-asset.md) section for more details.
+* If you are adding an EVM-compatible chain, that is much simpler, see [newevmchain.md].
 * For new coins you need to implement address handling and signing functionality in wallet-core (described in this section).  For new coins on already supported blockchains, or variations of already supported blockchains, please consider proper reuse of existing implementation.
 
 ## Integration Criteria

--- a/wallet-core/newevmchain.md
+++ b/wallet-core/newevmchain.md
@@ -29,6 +29,7 @@ swift/Tests/CoinAddressDerivationTests.swift
 - Run `tools/generate-files` to update generated sources.
 - Build the project, execute unit tests (see [building.md]).
 ```
+cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 make -Cbuild -j12 tests
 ./build/tests/tests tests
 ```

--- a/wallet-core/newevmchain.md
+++ b/wallet-core/newevmchain.md
@@ -1,0 +1,39 @@
+# Adding an EVM Chain
+
+Adding support for a new fully EVM-compatible chain to Wallet Core requires only a few changes, follow the steps here.
+For more complex chain integrations, see [newblockchain.md].
+
+## Prerequisties / Needed information
+
+- ETH `ChainID`.  EVM chains have a unique ChainID, such as `8217`.
+- `Derivation path` used.  Most EVM chains use Ethereum derivation path, `"m/44'/60'/0'/0/0"` (but not all).
+- `CoinID`.  Most EVM chains do not have a SLIP 44 CoinID, but some do.
+
+## Steps
+
+- Start with an up-to-date workspace (more info: [contributing.md]).
+- Add chain information to `registry.json`. Some notable fields:
+-- blockchain: "Ethereum",
+-- coinId: Should be set to: `10000000 + chainID`, such as `10008217`. If coinID is available, use that.
+- Run `codegen/bin/newcoin <chain>` to generate template source files.  
+- For EVM chains we will only need the `tests/<Chain>/TWCoinTypeTests.cpp` test file, discard all the other new files.
+- Discard changes in `include/TrustWalletCore/TWBlockchain.h` and `src/Coin.cpp`, no need for new blockchain type.
+- Check the test file `tests/X/TWCoinTypeTests.cpp` (`X` is the name of the blockchain).
+- There are some test cases test derivation for all coins.  Extend these with the new chain.
+If the new chain reuses Eth address, it can reuse the Eth case in the switch statements.
+```
+tests/CoinAddressDerivationTests.cpp
+android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt
+swift/Tests/CoinAddressDerivationTests.swift
+```
+- Run `tools/generate-files` to update generated sources.
+- Build the project, execute unit tests (see [building.md]).
+```
+make -Cbuild -j12 tests
+./build/tests/tests tests
+```
+- If all is fine, create a PR with the changes.
+
+## Some Examples:
+- https://github.com/trustwallet/wallet-core/pull/2307
+- https://github.com/trustwallet/wallet-core/pull/2157

--- a/wallet-core/newevmchain.md
+++ b/wallet-core/newevmchain.md
@@ -5,7 +5,7 @@ For more complex chain integrations, see [newblockchain.md].
 
 ## Prerequisties / Needed information
 
-- ETH `ChainID`.  EVM chains have a unique ChainID, such as `8217`.
+- `ChainID`.  EVM chains have a unique ChainID, such as `8217`.
 - `Derivation path` used.  Most EVM chains use Ethereum derivation path, `"m/44'/60'/0'/0/0"` (but not all).
 - `CoinID`.  Most EVM chains do not have a SLIP 44 CoinID, but some do.
 
@@ -20,7 +20,7 @@ For more complex chain integrations, see [newblockchain.md].
 - Discard changes in `include/TrustWalletCore/TWBlockchain.h` and `src/Coin.cpp`, no need for new blockchain type.
 - Check the test file `tests/X/TWCoinTypeTests.cpp` (`X` is the name of the blockchain).
 - There are some test cases test derivation for all coins.  Extend these with the new chain.
-If the new chain reuses Eth address, it can reuse the Eth case in the switch statements.
+If the new chain reuses Ethereum address, it can reuse the Ethereum case in the switch statements.
 ```
 tests/CoinAddressDerivationTests.cpp
 android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/CoinAddressDerivationTests.kt


### PR DESCRIPTION
Adding EVM chain is much simpler than an arbitrary chain, specialized instructions are created (a subset of general new chain).