### PR TITLE
fix missing `{` in the example code

### DIFF
--- a/develop-for-trust/browser-extension/evm.md
+++ b/develop-for-trust/browser-extension/evm.md
@@ -38,7 +38,7 @@ function getTrustWalletFromWindow() {
     return window.ethereum;
   }
 
-  if (window.ethereum?.providers)
+  if (window.ethereum?.providers) {
     return window.ethereum.providers.find(isTrustWallet) ?? null;
   }
 


### PR DESCRIPTION
The code had a closing `}`, but not an opening `{`.