### PR TITLE
Fiat deeplink

### DIFF
--- a/develop-for-trust/deeplinking/deeplinking.md
+++ b/develop-for-trust/deeplinking/deeplinking.md
@@ -93,8 +93,13 @@ Asset will be added to local storage and will show up on the wallet screen.
 ### Open Buy Crypto
 
 - `asset` asset in [UAI format](/assets/universal_asset_id.md)
+- `provider` Specifies the fiat ramp provider (e.g., moonpay, mercuryo, ramp). Optional.
+- `payment_method` Specifies the payment method (e.g., credit_card, bank_transfer, apple_pay, google_pay, digital_wallet). Optional.
+- `sub_payment_method` Specifies the sub payment method (e.g., paypal, skrill, blik). Optional.
+- `fiat_currency` Specifies the currency for the amount (e.g., USD, GBP). Optional.
+- `fiat_quantity` Specifies the default quantity of the asset to buy (e.g., 3, 0.25). Optional.
 
-`https://link.trustwallet.com/buy?asset=c60_t0x6B175474E89094C44Da98b954EedeAC495271d0F`
+`https://link.trustwallet.com/buy?asset=c60&provider=moonpay&payment_method=digital_wallet&sub_payment_method=paypal&fiat_currency=USD&fiat_quantity=300`
 
 ### Open Sell Crypto
 

--- a/develop-for-trust/deeplinking/deeplinking.md
+++ b/develop-for-trust/deeplinking/deeplinking.md
@@ -152,7 +152,7 @@ Open the Hot Tokens tab on the Swap page.
 
 `https://link.trustwallet.com/hot_tokens?category_id=hot`
 
-### Open Hot category and Bitcoin network
+### Open Hot category and specific network
 
 - `category_id` category identifier
 - `network` network identifier (slip44 index)


### PR DESCRIPTION
### Summary of Changes

This PR introduces updates to the `deeplinking.md` documentation, specifically enhancing the **Open Buy Crypto** section to support additional parameters and correcting the **Hot Tokens** section.

### Detailed Changes

1. **Correction in Hot Tokens Section**:
    - **Purpose**: Corrects the description from "Bitcoin network" to "specific network".
    - **URL**: `trust://hot_tokens?category_id=hot&network=c0`

    ```markdown
    ### Open Hot category and specific network

    - `category_id` category identifier
    - `network` network identifier (slip44 index)

    `trust://hot_tokens?category_id=hot&network=c0`
    ```

2. **Revised Open Buy Crypto Section**:
    - **Purpose**: Enhances the deep linking functionality for buying crypto by adding support for additional parameters.
    - **New Parameters**:
        - `provider`: Specifies the fiat ramp provider (e.g., moonpay, mercuryo, ramp). Optional.
        - `payment_method`: Specifies the payment method (e.g., credit_card, bank_transfer, apple_pay, google_pay, digital_wallet). Optional.
        - `sub_payment_method`: Specifies the sub payment method (e.g., paypal, skrill, blik). Optional.
        - `fiat_currency`: Specifies the currency for the amount (e.g., USD, GBP). Optional.
        - `fiat_quantity`: Specifies the default quantity of the asset to buy (e.g., 3, 0.25). Optional.

    ```markdown
    ### Open Buy Crypto

    - `asset` asset in [UAI format](/assets/universal_asset_id.md)
    - `provider` Specifies the fiat ramp provider (e.g., moonpay, mercuryo, ramp). Optional.
    - `payment_method` Specifies the payment method (e.g., credit_card, bank_transfer, apple_pay, google_pay, digital_wallet). Optional.
    - `sub_payment_method` Specifies the sub payment method (e.g., paypal, skrill, blik). Optional.
    - `fiat_currency` Specifies the currency for the amount (e.g., USD, GBP). Optional.
    - `fiat_quantity` Specifies the default quantity of the asset to buy (e.g., 3, 0.25). Optional.

    `https://link.trustwallet.com/buy?asset=c60&provider=moonpay&payment_method=digital_wallet&sub_payment_method=paypal&fiat_currency=USD&fiat_quantity=300`
    ```

### Reason for Changes

These additions and enhancements improve the documentation by providing clear and concise deep linking URLs for new features within the Trust Wallet application. The new parameters for the Buy Crypto section allow for a more streamlined and customized user experience.

### Impact

- **Product Operations & Marketing**: Can now use the provided URLs to directly link to the Hot Tokens tab and specific categories/networks within the Trust Wallet application. Additionally, they can use the enhanced Buy Crypto URLs to specify fiat ramp providers, payment methods, and default quantities.
- **Users**: Will benefit from seamless navigation to the Hot Tokens feature and a more customized experience when buying crypto via deep links.

### Testing

- Verified that the URLs correctly open the respective sections in the Trust Wallet application.
- Ensured that the format and structure of the documentation are consistent with existing content.
- Validated that the specified fiat ramp provider, payment method, and default quantity are correctly applied in the app.

### Documentation

Updated the `deeplinking.md` file to reflect the new parameters and their usage.