### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/assets/repository_details.md
+++ b/assets/repository_details.md
@@ -196,7 +196,7 @@ Sample `info.json`:
         },
         {
             "name": "twitter",
-            "url": "https://twitter.com/TrustWalletApp"
+            "url": "https://x.com/TrustWalletApp"
         },
         {
             "name": "reddit",

--- a/barz-smart-wallet/cutting-diamonds-how-to-make-accounts-awesome.md
+++ b/barz-smart-wallet/cutting-diamonds-how-to-make-accounts-awesome.md
@@ -1,6 +1,6 @@
-By [David Kim](https://twitter.com/0xDavidKim)
+By [David Kim](https://x.com/0xDavidKim)
 
-Special thanks to [Luis Ocegueda](https://twitter.com/luis_oce), [Artem Goryunov](https://twitter.com/ArtemGoryunov) and Dami Odufuwa for their feedback and contributions.
+Special thanks to [Luis Ocegueda](https://x.com/luis_oce), [Artem Goryunov](https://x.com/ArtemGoryunov) and Dami Odufuwa for their feedback and contributions.
 
 
 This is the second of an article series on Barz. 

--- a/barz-smart-wallet/introducing-barz-trustwallet-smart-wallet-solution.md
+++ b/barz-smart-wallet/introducing-barz-trustwallet-smart-wallet-solution.md
@@ -1,7 +1,7 @@
-By [David Kim](https://twitter.com/0xDavidKim)
+By [David Kim](https://x.com/0xDavidKim)
 
 
-Special thanks to [Luis Ocegueda](https://twitter.com/luis_oce) and [Artem Goryunov](https://twitter.com/ArtemGoryunov) for their feedback and contributions.
+Special thanks to [Luis Ocegueda](https://x.com/luis_oce) and [Artem Goryunov](https://x.com/ArtemGoryunov) for their feedback and contributions.
 
 
 

--- a/dapps/listing-guide.md
+++ b/dapps/listing-guide.md
@@ -4,7 +4,7 @@ Joining the Trust Wallet ecosystem with an already established base of users, pr
 
 Trust Wallet is proud of the high standards of quality required for listed dApps, where the user and their experience are the key areas of focus. The app is one of the most popular wallets available for easy access to digital assets and dApps in one place.
 
-By improving the functionality of your project and its overall optimization, you allow users already familiar with the Trust Wallet space the best chance of using your dApp. Taking advantage of the vibrant [community](https://twitter.com/trustwalletapp) is a logical step to take. Marketing efforts also help, so get in touch with the Trust Wallet team via [Trust Wallet Community](https://community.trustwallet.com/) to explore more promotional opportunities.
+By improving the functionality of your project and its overall optimization, you allow users already familiar with the Trust Wallet space the best chance of using your dApp. Taking advantage of the vibrant [community](https://x.com/trustwalletapp) is a logical step to take. Marketing efforts also help, so get in touch with the Trust Wallet team via [Trust Wallet Community](https://community.trustwallet.com/) to explore more promotional opportunities.
 
 Missing out on just any one part of the optimization and application process will ultimately lead to an unsuccessful application. The journey involves rounds of:
 


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.