### PR TITLE
docs: add Trust Wallet Agent SDK documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This documentation covers everything for developers: building on top of Trust Wa
 
 ---
 
+## Trust Wallet Agent SDK
+
+### [Agent SDK](agent-sdk/agent-sdk.md)
+Programmatic access to Trust Wallet's multichain infrastructure — balance queries, token prices, swaps, transaction history, and more — through a CLI and an MCP server for AI agents.
+
+- [Quickstart](agent-sdk/quickstart.md)
+- [CLI Reference](agent-sdk/cli-reference.md)
+- [Authentication](agent-sdk/authentication.md)
+
+---
+
 ## Build on Trust Wallet
 
 ### [Developing for Trust Wallet](develop-for-trust/develop-for-trust.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,10 @@
 # Table of contents
 
 - [Get Started](README.md)
+- [Trust Wallet Agent SDK](agent-sdk/agent-sdk.md)
+  - [Quickstart](agent-sdk/quickstart.md)
+  - [CLI Reference](agent-sdk/cli-reference.md)
+  - [Authentication](agent-sdk/authentication.md)
 - [MCP Server](mcp/mcp.md)
 - [Agent Skills](claude-code-skills/claude-code-skills.md)
 - [Developing for Trust Wallet platform](develop-for-trust/develop-for-trust.md)

--- a/agent-sdk/agent-sdk.md
+++ b/agent-sdk/agent-sdk.md
@@ -1,0 +1,21 @@
+# Trust Wallet Agent SDK
+
+The Trust Wallet Agent SDK gives developers programmatic access to Trust Wallet's multichain infrastructure — balance queries, token prices, swaps, transaction history, and more — through a CLI, a TypeScript SDK, and an MCP server for AI agents.
+
+## What's included
+
+| Package | Description |
+|---------|-------------|
+| `@twak/cli` | Command-line interface — `twak` / `tw-agent` binaries |
+| `@twak/sdk` | TypeScript SDK for server-side and agent integrations |
+| MCP server | `twak serve` — connect any MCP-compatible AI agent |
+
+## Get started
+
+- [Quickstart](quickstart.md) — install the CLI and make your first request in 5 minutes
+- [CLI Reference](cli-reference.md) — all commands, subcommands, and flags
+- [Authentication](authentication.md) — API keys and HMAC signing
+
+## Developer portal
+
+Create and manage your API keys at [developer.trustwallet.com](https://developer.trustwallet.com).

--- a/agent-sdk/agent-sdk.md
+++ b/agent-sdk/agent-sdk.md
@@ -18,4 +18,4 @@ The Trust Wallet Agent SDK gives developers programmatic access to Trust Wallet'
 
 ## Developer portal
 
-Create and manage your API keys at [developer.trustwallet.com](https://developer.trustwallet.com).
+Create and manage your API keys at [portal.trustwallet.com](https://portal.trustwallet.com).

--- a/agent-sdk/agent-sdk.md
+++ b/agent-sdk/agent-sdk.md
@@ -1,14 +1,12 @@
 # Trust Wallet Agent SDK
 
-The Trust Wallet Agent SDK gives developers programmatic access to Trust Wallet's multichain infrastructure — balance queries, token prices, swaps, transaction history, and more — through a CLI, a TypeScript SDK, and an MCP server for AI agents.
+The Trust Wallet Agent SDK gives developers programmatic access to Trust Wallet's multichain infrastructure — balance queries, token prices, swaps, transaction history, and more — through a CLI and an MCP server for AI agents.
 
-## What's included
+## Install
 
-| Package | Description |
-|---------|-------------|
-| `@trustwallet/cli` | Command-line interface — `twak` binary |
-| `@twak/*` | TypeScript SDK packages for server-side and agent integrations |
-| MCP server | `twak serve` — connect any MCP-compatible AI agent |
+```bash
+npm install -g @trustwallet/cli
+```
 
 ## Get started
 

--- a/agent-sdk/agent-sdk.md
+++ b/agent-sdk/agent-sdk.md
@@ -6,8 +6,8 @@ The Trust Wallet Agent SDK gives developers programmatic access to Trust Wallet'
 
 | Package | Description |
 |---------|-------------|
-| `@twak/cli` | Command-line interface — `twak` / `tw-agent` binaries |
-| `@twak/sdk` | TypeScript SDK for server-side and agent integrations |
+| `@trustwallet/cli` | Command-line interface — `twak` binary |
+| `@twak/*` | TypeScript SDK packages for server-side and agent integrations |
 | MCP server | `twak serve` — connect any MCP-compatible AI agent |
 
 ## Get started

--- a/agent-sdk/agent-sdk.md
+++ b/agent-sdk/agent-sdk.md
@@ -5,8 +5,10 @@ The Trust Wallet Agent SDK gives developers programmatic access to Trust Wallet'
 ## Install
 
 ```bash
-npm install -g @trustwallet/cli
+npx @trustwallet/cli --version
 ```
+
+Or install globally: `npm install -g @trustwallet/cli`
 
 ## Get started
 

--- a/agent-sdk/authentication.md
+++ b/agent-sdk/authentication.md
@@ -4,7 +4,7 @@ All requests to the Trust Wallet API are authenticated with an **API access ID**
 
 ## Getting credentials
 
-1. Sign in at [developer.trustwallet.com](https://developer.trustwallet.com)
+1. Sign in at [portal.trustwallet.com](https://portal.trustwallet.com)
 2. Create an app, then create an API key inside it
 3. Copy your **Access ID** (`twk_live_...`) and **HMAC Secret** — the secret is shown only once
 
@@ -24,39 +24,50 @@ export TWAK_HMAC_SECRET=your_hmac_secret
 
 ## How HMAC signing works
 
-Every API request is signed with HMAC-SHA256 over four fields joined by newlines:
+Every API request is signed with HMAC-SHA256 over six fields concatenated together:
 
 ```
-METHOD\nPATH\nNONCE\nBODY
+METHOD + PATH + QUERY + ACCESS_ID + NONCE + DATE
 ```
 
 | Field | Description |
 |-------|-------------|
 | `METHOD` | HTTP method in uppercase — `GET`, `POST`, `DELETE` |
 | `PATH` | URL path without query string — `/v1/wallet/balance` |
-| `NONCE` | Unix timestamp in milliseconds — prevents replay attacks |
-| `BODY` | JSON-encoded request body, or empty string for GET |
+| `QUERY` | Query string (without leading `?`), or empty string |
+| `ACCESS_ID` | Your API access ID |
+| `NONCE` | Unique random string — prevents replay attacks |
+| `DATE` | ISO 8601 timestamp — validated within a ±5 min window |
 
-The resulting base64 signature is sent in the `X-TW-Signature` header alongside `X-TW-Access-Id` and `X-TW-Nonce`.
+The resulting base64 signature is sent in the `Authorization` header. Three additional headers identify the request:
+
+| Header | Value |
+|--------|-------|
+| `X-TW-Credential` | Your API access ID |
+| `X-TW-Nonce` | The nonce used in signing |
+| `X-TW-Date` | The timestamp used in signing |
+| `Authorization` | Base64-encoded HMAC-SHA256 signature |
 
 The CLI and TypeScript SDK handle signing automatically — you only need to understand this if you are making raw HTTP calls.
 
 ## Raw HTTP example
 
 ```bash
-NONCE=$(date +%s%3N)
+ACCESS_ID="$TWAK_ACCESS_ID"
+NONCE=$(uuidgen | tr -d '-')
+DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 METHOD="GET"
-PATH="/v1/wallet/balance"
-BODY=""
-SIGNATURE=$(echo -n "$METHOD\n$PATH\n$NONCE\n$BODY" \
+REQ_PATH="/v1/wallet/balance"
+QUERY="address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045&chain=ethereum"
+SIGNATURE=$(printf '%s' "${METHOD}${REQ_PATH}${QUERY}${ACCESS_ID}${NONCE}${DATE}" \
   | openssl dgst -sha256 -hmac "$TWAK_HMAC_SECRET" -binary \
   | base64)
 
-curl -X GET "https://api.trustwallet.com/v1/wallet/balance?\
-  address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045&chain=ethereum" \
-  -H "X-TW-Access-Id: $TWAK_ACCESS_ID" \
+curl -X GET "https://api.trustwallet.com${REQ_PATH}?${QUERY}" \
+  -H "X-TW-Credential: $ACCESS_ID" \
   -H "X-TW-Nonce: $NONCE" \
-  -H "X-TW-Signature: $SIGNATURE"
+  -H "X-TW-Date: $DATE" \
+  -H "Authorization: $SIGNATURE"
 ```
 
 ## Security best practices

--- a/agent-sdk/authentication.md
+++ b/agent-sdk/authentication.md
@@ -1,0 +1,67 @@
+# Authentication
+
+All requests to the Trust Wallet API are authenticated with an **API access ID** and an **HMAC-SHA256 signature** derived from your HMAC secret.
+
+## Getting credentials
+
+1. Sign in at [developer.trustwallet.com](https://developer.trustwallet.com)
+2. Create an app, then create an API key inside it
+3. Copy your **Access ID** (`twk_live_...`) and **HMAC Secret** — the secret is shown only once
+
+## Configuring the CLI
+
+```bash
+twak init --api-key twk_live_your_access_id \
+          --api-secret your_hmac_secret
+```
+
+Or via environment variables:
+
+```bash
+export TWAK_ACCESS_ID=twk_live_your_access_id
+export TWAK_HMAC_SECRET=your_hmac_secret
+```
+
+## How HMAC signing works
+
+Every API request is signed with HMAC-SHA256 over four fields joined by newlines:
+
+```
+METHOD\nPATH\nNONCE\nBODY
+```
+
+| Field | Description |
+|-------|-------------|
+| `METHOD` | HTTP method in uppercase — `GET`, `POST`, `DELETE` |
+| `PATH` | URL path without query string — `/v1/wallet/balance` |
+| `NONCE` | Unix timestamp in milliseconds — prevents replay attacks |
+| `BODY` | JSON-encoded request body, or empty string for GET |
+
+The resulting base64 signature is sent in the `X-TW-Signature` header alongside `X-TW-Access-Id` and `X-TW-Nonce`.
+
+The CLI and TypeScript SDK handle signing automatically — you only need to understand this if you are making raw HTTP calls.
+
+## Raw HTTP example
+
+```bash
+NONCE=$(date +%s%3N)
+METHOD="GET"
+PATH="/v1/wallet/balance"
+BODY=""
+SIGNATURE=$(echo -n "$METHOD\n$PATH\n$NONCE\n$BODY" \
+  | openssl dgst -sha256 -hmac "$TWAK_HMAC_SECRET" -binary \
+  | base64)
+
+curl -X GET "https://api.trustwallet.com/v1/wallet/balance?\
+  address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045&chain=ethereum" \
+  -H "X-TW-Access-Id: $TWAK_ACCESS_ID" \
+  -H "X-TW-Nonce: $NONCE" \
+  -H "X-TW-Signature: $SIGNATURE"
+```
+
+## Security best practices
+
+- Never commit your HMAC secret to version control
+- Add `.env` to `.gitignore`
+- Rotate keys regularly from the developer portal
+- Use separate keys for development and production

--- a/agent-sdk/authentication.md
+++ b/agent-sdk/authentication.md
@@ -10,17 +10,21 @@ All requests to the Trust Wallet API are authenticated with an **API access ID**
 
 ## Configuring the CLI
 
+The recommended approach is `twak init`, which stores credentials in `~/.twak/credentials.json` with `0600` permissions:
+
 ```bash
 twak init --api-key your_access_id \
           --api-secret your_hmac_secret
 ```
 
-Or via environment variables:
+For CI/CD pipelines, use environment variables:
 
 ```bash
 export TWAK_ACCESS_ID=your_access_id
 export TWAK_HMAC_SECRET=your_hmac_secret
 ```
+
+> **Do not add these exports to shell config files** (`~/.zshrc`, `~/.bashrc`). Use `twak init` for persistent local credentials. Env vars are intended for ephemeral CI/CD environments where secrets are injected at runtime.
 
 ## How HMAC signing works
 
@@ -72,7 +76,9 @@ curl -X GET "https://tws.trustwallet.com${REQ_PATH}?${QUERY}" \
 
 ## Security best practices
 
-- Never commit your HMAC secret to version control
-- Add `.env` to `.gitignore`
+- Use `twak init` for local credentials — stores in `~/.twak/credentials.json` with restricted permissions
+- Use `twak wallet keychain save` to store the wallet password in the OS keychain (macOS Keychain / Linux Secret Service)
+- Never commit your HMAC secret to version control — add `.env` to `.gitignore`
+- Never add credentials to shell config files (`~/.zshrc`, `~/.bashrc`) — use `twak init` instead
 - Rotate keys regularly from the developer portal
 - Use separate keys for development and production

--- a/agent-sdk/authentication.md
+++ b/agent-sdk/authentication.md
@@ -6,19 +6,19 @@ All requests to the Trust Wallet API are authenticated with an **API access ID**
 
 1. Sign in at [portal.trustwallet.com](https://portal.trustwallet.com)
 2. Create an app, then create an API key inside it
-3. Copy your **Access ID** (`twk_live_...`) and **HMAC Secret** — the secret is shown only once
+3. Copy your **Access ID** and **HMAC Secret** — the secret is shown only once
 
 ## Configuring the CLI
 
 ```bash
-twak init --api-key twk_live_your_access_id \
+twak init --api-key your_access_id \
           --api-secret your_hmac_secret
 ```
 
 Or via environment variables:
 
 ```bash
-export TWAK_ACCESS_ID=twk_live_your_access_id
+export TWAK_ACCESS_ID=your_access_id
 export TWAK_HMAC_SECRET=your_hmac_secret
 ```
 
@@ -57,8 +57,8 @@ ACCESS_ID="$TWAK_ACCESS_ID"
 NONCE=$(uuidgen | tr -d '-')
 DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 METHOD="GET"
-REQ_PATH="/v1/wallet/balance"
-QUERY="address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045&chain=ethereum"
+REQ_PATH="/v1/search/assets"
+QUERY="query=ethereum&limit=5"
 SIGNATURE=$(printf '%s' "${METHOD}${REQ_PATH}${QUERY}${ACCESS_ID}${NONCE}${DATE}" \
   | openssl dgst -sha256 -hmac "$TWAK_HMAC_SECRET" -binary \
   | base64)

--- a/agent-sdk/authentication.md
+++ b/agent-sdk/authentication.md
@@ -39,7 +39,7 @@ METHOD + PATH + QUERY + ACCESS_ID + NONCE + DATE
 | `NONCE` | Unique random string — prevents replay attacks |
 | `DATE` | ISO 8601 timestamp — validated within a ±5 min window |
 
-The resulting base64 signature is sent in the `Authorization` header. Three additional headers identify the request:
+The resulting base64 signature is sent in the `Authorization` header. Four headers are required on every request:
 
 | Header | Value |
 |--------|-------|

--- a/agent-sdk/authentication.md
+++ b/agent-sdk/authentication.md
@@ -63,7 +63,7 @@ SIGNATURE=$(printf '%s' "${METHOD}${REQ_PATH}${QUERY}${ACCESS_ID}${NONCE}${DATE}
   | openssl dgst -sha256 -hmac "$TWAK_HMAC_SECRET" -binary \
   | base64)
 
-curl -X GET "https://api.trustwallet.com${REQ_PATH}?${QUERY}" \
+curl -X GET "https://tws.trustwallet.com${REQ_PATH}?${QUERY}" \
   -H "X-TW-Credential: $ACCESS_ID" \
   -H "X-TW-Nonce: $NONCE" \
   -H "X-TW-Date: $DATE" \

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -1,0 +1,318 @@
+# CLI Reference
+
+The `twak` CLI (also aliased as `tw-agent`) provides full access to the Trust Wallet Agent SDK from the command line.
+
+**Install:** `npm install -g @twak/cli`
+
+---
+
+## init
+
+Initialize configuration and save credentials.
+
+```bash
+twak init --api-key <key> --api-secret <secret> [--wc-project-id <id>]
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--api-key` | Yes | TWAK API access ID |
+| `--api-secret` | Yes | HMAC secret |
+| `--wc-project-id` | No | WalletConnect project ID |
+
+Credentials are saved to `~/.tw-agent/credentials.json`.
+
+---
+
+## auth
+
+### auth setup
+
+```bash
+twak auth setup --api-key <key> --api-secret <secret>
+```
+
+### auth status
+
+```bash
+twak auth status [--json]
+```
+
+---
+
+## wallet
+
+### wallet create
+
+```bash
+twak wallet create --password <pw> [--json]
+```
+
+### wallet address
+
+```bash
+twak wallet address --chain <chain> --password <pw> [--json]
+```
+
+### wallet addresses
+
+```bash
+twak wallet addresses --password <pw> [--json]
+```
+
+### wallet balance
+
+```bash
+twak wallet balance --chain <chain> --password <pw> [--json]
+```
+
+### wallet export
+
+```bash
+twak wallet export --password <pw>
+```
+
+### wallet connect
+
+Connect an external wallet via WalletConnect.
+
+```bash
+twak wallet connect [--json]
+```
+
+### wallet status
+
+```bash
+twak wallet status [--json]
+```
+
+---
+
+## transfer
+
+```bash
+twak transfer --to <address> --amount <amount> --token <token> --password <pw> [--json]
+```
+
+---
+
+## swap
+
+```bash
+twak swap <amount> <from> <to> [--chain <chain>] [--to-chain <chain>] \
+          [--slippage <pct>] [--quote-only] [--password <pw>] [--json]
+```
+
+Use `--quote-only` to preview without executing.
+
+---
+
+## price
+
+```bash
+twak price <token> [--chain <chain>] [--json]
+```
+
+Default chain is `ethereum`.
+
+---
+
+## balance
+
+Get the native balance for any address using a SLIP44 coin ID.
+
+```bash
+twak balance --address <address> --coin <coinId> [--json]
+```
+
+Common coin IDs: `60` (Ethereum), `0` (Bitcoin), `501` (Solana).
+
+---
+
+## holdings
+
+```bash
+twak holdings --address <address> --coin <coinId> [--json]
+```
+
+---
+
+## search
+
+```bash
+twak search <query> [--networks <ids>] [--limit <n>] [--json]
+```
+
+---
+
+## trending
+
+```bash
+twak trending [--limit <n>] [--json]
+```
+
+---
+
+## history
+
+```bash
+twak history --address <address> [--chain <chain>] [--from <date>] \
+             [--to <date>] [--limit <n>] [--json]
+```
+
+---
+
+## tx
+
+```bash
+twak tx <hash> --chain <chain> [--json]
+```
+
+---
+
+## chains
+
+```bash
+twak chains [--json]
+```
+
+---
+
+## asset
+
+```bash
+twak asset <assetId> [--json]
+```
+
+---
+
+## validate
+
+```bash
+twak validate --address <address> [--asset-id <id>] [--json]
+```
+
+---
+
+## risk
+
+Check token security and rug-risk info.
+
+```bash
+twak risk <assetId> [--json]
+```
+
+---
+
+## erc20
+
+### erc20 approve
+
+```bash
+twak erc20 approve --token <address> --spender <address> --amount <amount> \
+                   --password <pw> [--json]
+```
+
+### erc20 allowance
+
+```bash
+twak erc20 allowance --token <address> --owner <address> --spender <address> [--json]
+```
+
+---
+
+## alert
+
+### alert create
+
+```bash
+twak alert create --token <token> --chain <chain> (--above <price> | --below <price>) [--json]
+```
+
+### alert list
+
+```bash
+twak alert list [--active] [--json]
+```
+
+### alert check
+
+```bash
+twak alert check [--json]
+```
+
+### alert delete
+
+```bash
+twak alert delete <id> [--json]
+```
+
+---
+
+## onramp
+
+### onramp quote
+
+```bash
+twak onramp quote --amount <amount> --asset <asset> --wallet <address> \
+                  [--currency <fiat>] [--json]
+```
+
+### onramp buy
+
+```bash
+twak onramp buy --quote-id <id> --wallet <address> [--json]
+```
+
+### onramp sell-quote
+
+```bash
+twak onramp sell-quote --amount <amount> --asset <asset> --wallet <address> \
+                       [--currency <fiat>] [--method <method>] [--json]
+```
+
+### onramp sell
+
+```bash
+twak onramp sell --quote-id <id> --wallet <address> [--json]
+```
+
+---
+
+## automate
+
+### automate add
+
+Create a DCA or limit order automation.
+
+```bash
+twak automate add --from <token> --to <token> --amount <amount> \
+                  [--chain <chain>] [--interval <interval>] \
+                  [--price <price>] [--condition above|below] [--json]
+```
+
+### automate list
+
+```bash
+twak automate list [--all] [--json]
+```
+
+### automate delete
+
+```bash
+twak automate delete <id> [--json]
+```
+
+---
+
+## serve
+
+Start an MCP server (stdio) or REST API server for AI agent integrations.
+
+```bash
+twak serve [--rest] [--port <port>] [--x402] \
+           [--payment-amount <amount>] [--payment-asset <asset>] \
+           [--payment-chain <chain>] [--payment-recipient <address>]
+```
+
+Use `--rest` to start an HTTP server instead of stdio MCP.

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -29,7 +29,7 @@ Credentials are saved to `~/.tw-agent/credentials.json`.
 ### auth setup
 
 ```bash
-twak auth setup --api-key <key> --api-secret <secret>
+twak auth setup --api-key <key> --api-secret <secret> [--wc-project-id <id>]
 ```
 
 ### auth status
@@ -45,31 +45,53 @@ twak auth status [--json]
 ### wallet create
 
 ```bash
-twak wallet create --password <pw> [--json]
+twak wallet create --password <pw> [--no-keychain] [--json]
 ```
 
 ### wallet address
 
 ```bash
-twak wallet address --chain <chain> --password <pw> [--json]
+twak wallet address --chain <chain> [--password <pw>] [--json]
 ```
+
+Password falls back to the OS keychain or `TWAK_WALLET_PASSWORD` environment variable.
 
 ### wallet addresses
 
 ```bash
-twak wallet addresses --password <pw> [--json]
+twak wallet addresses [--password <pw>] [--json]
 ```
 
 ### wallet balance
 
 ```bash
-twak wallet balance --chain <chain> --password <pw> [--json]
+twak wallet balance --chain <chain> [--password <pw>] [--json]
 ```
 
 ### wallet export
 
 ```bash
-twak wallet export --password <pw>
+twak wallet export [--password <pw>]
+```
+
+### wallet keychain save
+
+Save the wallet password to the OS keychain for passwordless usage.
+
+```bash
+twak wallet keychain save --password <pw>
+```
+
+### wallet keychain delete
+
+```bash
+twak wallet keychain delete
+```
+
+### wallet keychain check
+
+```bash
+twak wallet keychain check
 ```
 
 ### wallet connect
@@ -209,14 +231,16 @@ twak risk <assetId> [--json]
 ### erc20 approve
 
 ```bash
-twak erc20 approve --token <address> --spender <address> --amount <amount> \
+twak erc20 approve --token <assetId> --spender <address> --amount <amount> \
                    --password <pw> [--json]
 ```
+
+Token uses the Trust Wallet asset ID format (e.g., `c60_t0xA0b8...`).
 
 ### erc20 allowance
 
 ```bash
-twak erc20 allowance --token <address> --owner <address> --spender <address> [--json]
+twak erc20 allowance --token <assetId> --owner <address> --spender <address> [--json]
 ```
 
 ---

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -1,8 +1,8 @@
 # CLI Reference
 
-The `twak` CLI (also aliased as `tw-agent`) provides full access to the Trust Wallet Agent SDK from the command line.
+The `twak` CLI provides full access to the Trust Wallet Agent SDK from the command line.
 
-**Install:** `npm install -g @twak/cli`
+**Install:** `npm install -g @trustwallet/cli`
 
 ---
 
@@ -11,16 +11,15 @@ The `twak` CLI (also aliased as `tw-agent`) provides full access to the Trust Wa
 Initialize configuration and save credentials.
 
 ```bash
-twak init --api-key <key> --api-secret <secret> [--wc-project-id <id>]
+twak init --api-key <key> --api-secret <secret>
 ```
 
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--api-key` | Yes | TWAK API access ID |
 | `--api-secret` | Yes | HMAC secret |
-| `--wc-project-id` | No | WalletConnect project ID |
 
-Credentials are saved to `~/.tw-agent/credentials.json`.
+Credentials are saved to `~/.twak/credentials.json`.
 
 ---
 
@@ -29,7 +28,7 @@ Credentials are saved to `~/.tw-agent/credentials.json`.
 ### auth setup
 
 ```bash
-twak auth setup --api-key <key> --api-secret <secret> [--wc-project-id <id>]
+twak auth setup --api-key <key> --api-secret <secret>
 ```
 
 ### auth status
@@ -68,6 +67,24 @@ twak wallet addresses [--password <pw>] [--json]
 twak wallet balance --chain <chain> [--password <pw>] [--json]
 ```
 
+### wallet portfolio
+
+Full portfolio across all chains — native balances, token holdings, and USD values.
+
+```bash
+twak wallet portfolio [--chains <list>] [--password <pw>] [--json]
+```
+
+Default chains include all major EVM chains plus Solana and TRON.
+
+### wallet sign-message
+
+Sign an arbitrary message with the agent wallet key.
+
+```bash
+twak wallet sign-message --chain <chain> --message <text> [--password <pw>] [--json]
+```
+
 ### wallet export
 
 ```bash
@@ -94,14 +111,6 @@ twak wallet keychain delete
 twak wallet keychain check
 ```
 
-### wallet connect
-
-Connect an external wallet via WalletConnect.
-
-```bash
-twak wallet connect [--json]
-```
-
 ### wallet status
 
 ```bash
@@ -113,8 +122,18 @@ twak wallet status [--json]
 ## transfer
 
 ```bash
-twak transfer --to <address> --amount <amount> --token <token> --password <pw> [--json]
+twak transfer --to <address> --amount <amount> --token <token> \
+              [--max-usd <n>] [--skip-safety-check] [--password <pw>] [--json]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--to` | Destination address or ENS name (e.g., `vitalik.eth`) |
+| `--amount` | Amount in human-readable format |
+| `--token` | Asset ID (e.g., `c60` for ETH, `c60_t0xA0b8...` for ERC-20) |
+| `--max-usd` | Maximum allowed transfer value in USD (default: 10000) |
+| `--skip-safety-check` | Skip the USD-value safety check |
+| `--confirm-to` | Pin expected resolved address — rejects if ENS resolves differently |
 
 ---
 
@@ -124,6 +143,13 @@ twak transfer --to <address> --amount <amount> --token <token> --password <pw> [
 twak swap <amount> <from> <to> [--chain <chain>] [--to-chain <chain>] \
           [--slippage <pct>] [--quote-only] [--password <pw>] [--json]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--chain` | Source chain (default: ethereum) |
+| `--to-chain` | Destination chain for cross-chain swaps |
+| `--slippage` | Slippage tolerance % (default: 1, max: 50) |
+| `--quote-only` | Preview quote without executing |
 
 Use `--quote-only` to preview without executing.
 
@@ -135,7 +161,7 @@ Use `--quote-only` to preview without executing.
 twak price <token> [--chain <chain>] [--json]
 ```
 
-Default chain is `ethereum`.
+Chain is auto-detected from native token symbols (ETH, BNB, SOL, etc.).
 
 ---
 
@@ -170,8 +196,24 @@ twak search <query> [--networks <ids>] [--limit <n>] [--json]
 ## trending
 
 ```bash
-twak trending [--limit <n>] [--json]
+twak trending [--category <cat>] [--sort <field>] [--limit <n>] [--json]
 ```
+
+Categories: `ai`, `rwa`, `memes`, `defi`, `dex`, `bnb`, `eth`, `sol`, `pumpfun`, `launchpad`, `layer1`.
+
+Sort fields: `price_change` (default), `market_cap`, `volume`.
+
+---
+
+## dapps
+
+Browse featured DApps and protocols.
+
+```bash
+twak dapps [--category <cat>] [--json]
+```
+
+Categories: `defi`, `dex`, `lending`, `nft`, `gaming`, `social`.
 
 ---
 
@@ -232,10 +274,16 @@ twak risk <assetId> [--json]
 
 ```bash
 twak erc20 approve --token <assetId> --spender <address> --amount <amount> \
-                   --password <pw> [--json]
+                   [--confirm-unlimited] --password <pw> [--json]
 ```
 
 Token uses the Trust Wallet asset ID format (e.g., `c60_t0xA0b8...`).
+
+### erc20 revoke
+
+```bash
+twak erc20 revoke --token <assetId> --spender <address> --password <pw> [--json]
+```
 
 ### erc20 allowance
 
@@ -273,70 +321,22 @@ twak alert delete <id> [--json]
 
 ---
 
-## onramp
-
-### onramp quote
-
-```bash
-twak onramp quote --amount <amount> --asset <asset> --wallet <address> \
-                  [--currency <fiat>] [--json]
-```
-
-### onramp buy
-
-```bash
-twak onramp buy --quote-id <id> --wallet <address> [--json]
-```
-
-### onramp sell-quote
-
-```bash
-twak onramp sell-quote --amount <amount> --asset <asset> --wallet <address> \
-                       [--currency <fiat>] [--method <method>] [--json]
-```
-
-### onramp sell
-
-```bash
-twak onramp sell --quote-id <id> --wallet <address> [--json]
-```
-
----
-
-## automate
-
-### automate add
-
-Create a DCA or limit order automation.
-
-```bash
-twak automate add --from <token> --to <token> --amount <amount> \
-                  [--chain <chain>] [--interval <interval>] \
-                  [--price <price>] [--condition above|below] [--json]
-```
-
-### automate list
-
-```bash
-twak automate list [--all] [--json]
-```
-
-### automate delete
-
-```bash
-twak automate delete <id> [--json]
-```
-
----
-
 ## serve
 
 Start an MCP server (stdio) or REST API server for AI agent integrations.
 
 ```bash
-twak serve [--rest] [--port <port>] [--x402] \
-           [--payment-amount <amount>] [--payment-asset <asset>] \
+twak serve [--rest] [--port <port>] [--host <host>] \
+           [--auto-lock <minutes>] [--password <pw>] \
+           [--x402] [--payment-amount <amount>] [--payment-asset <asset>] \
            [--payment-chain <chain>] [--payment-recipient <address>]
 ```
 
-Use `--rest` to start an HTTP server instead of stdio MCP.
+| Flag | Description |
+|------|-------------|
+| `--rest` | Start REST HTTP server instead of MCP stdio |
+| `--port` | Port for REST server (default: 3000) |
+| `--auto-lock` | Auto-lock wallet after N minutes of inactivity |
+| `--x402` | Require x402 micropayment for REST endpoints |
+
+The REST server requires Bearer token authentication using your HMAC secret.

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -64,8 +64,10 @@ twak wallet addresses [--password <pw>] [--json]
 ### wallet balance
 
 ```bash
-twak wallet balance --chain <chain> [--password <pw>] [--json]
+twak wallet balance [--chain <chain>] [--all] [--no-tokens] [--password <pw>] [--json]
 ```
+
+Use `--all` to show balances across all chains with funds. Use `--no-tokens` to skip token balance lookup.
 
 ### wallet portfolio
 
@@ -172,14 +174,6 @@ Common coin IDs: `60` (Ethereum), `0` (Bitcoin), `501` (Solana).
 
 ---
 
-## holdings
-
-```bash
-twak holdings --address <address> --coin <coinId> [--json]
-```
-
----
-
 ## search
 
 ```bash
@@ -194,7 +188,7 @@ twak search <query> [--networks <ids>] [--limit <n>] [--json]
 twak trending [--category <cat>] [--sort <field>] [--limit <n>] [--json]
 ```
 
-Categories: `ai`, `rwa`, `memes`, `defi`, `dex`, `bnb`, `eth`, `sol`, `pumpfun`, `launchpad`, `layer1`.
+Categories: `ai`, `rwa`, `memes`, `defi`, `dex`, `bnb`, `eth`, `sol`, `pumpfun`, `bonk`, `launchpad`, `launchpool`, `layer1`.
 
 Sort fields: `price_change` (default), `market_cap`, `volume`.
 
@@ -205,10 +199,10 @@ Sort fields: `price_change` (default), `market_cap`, `volume`.
 Browse featured DApps and protocols.
 
 ```bash
-twak dapps [--category <cat>] [--json]
+twak dapps [--category <cat>] [--search <query>] [--categories] [--limit <n>] [--json]
 ```
 
-Categories: `defi`, `dex`, `lending`, `nft`, `gaming`, `social`.
+Categories: `defi`, `dex`, `lending`, `nft`, `gaming`, `social`. Use `--categories` to list all available.
 
 ---
 

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -117,7 +117,8 @@ twak wallet status [--json]
 
 ```bash
 twak transfer --to <address> --amount <amount> --token <token> \
-              [--max-usd <n>] [--skip-safety-check] [--password <pw>] [--json]
+              [--confirm-to <address>] [--max-usd <n>] [--skip-safety-check] \
+              [--password <pw>] [--json]
 ```
 
 | Flag | Description |
@@ -333,4 +334,4 @@ twak serve [--rest] [--port <port>] [--host <host>] \
 | `--auto-lock` | Auto-lock wallet after N minutes of inactivity |
 | `--x402` | Require x402 micropayment for REST endpoints |
 
-The REST server requires Bearer token authentication using your HMAC secret.
+The REST server authenticates requests via `Authorization: Bearer <HMAC_SECRET>`. This is separate from the HMAC signing used by `tws.trustwallet.com` — the REST server runs locally and uses the raw secret as a shared token for simplicity.

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -2,7 +2,7 @@
 
 The `twak` CLI provides full access to the Trust Wallet Agent SDK from the command line.
 
-**Install:** `npm install -g @trustwallet/cli`
+**Run:** `npx @trustwallet/cli <command>` or install globally with `npm install -g @trustwallet/cli`
 
 ---
 

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -85,12 +85,6 @@ Sign an arbitrary message with the agent wallet key.
 twak wallet sign-message --chain <chain> --message <text> [--password <pw>] [--json]
 ```
 
-### wallet export
-
-```bash
-twak wallet export [--password <pw>]
-```
-
 ### wallet keychain save
 
 Save the wallet password to the OS keychain for passwordless usage.

--- a/agent-sdk/quickstart.md
+++ b/agent-sdk/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart
+
+Get from zero to your first API call in under 5 minutes using the `twak` CLI.
+
+## Step 1 — Install the CLI
+
+```bash
+npm install -g @twak/cli
+```
+
+Verify the install:
+
+```bash
+twak --version
+```
+
+The CLI exposes two aliases: `twak` and `tw-agent`.
+
+## Step 2 — Configure credentials
+
+Get your API key and HMAC secret from the [developer portal](https://developer.trustwallet.com/dashboard/keys), then run:
+
+```bash
+twak init --api-key twk_live_your_access_id \
+          --api-secret your_hmac_secret
+```
+
+Credentials are stored in `~/.tw-agent/credentials.json`.
+
+Alternatively, export environment variables (useful in CI/CD):
+
+```bash
+export TWAK_ACCESS_ID=twk_live_your_access_id
+export TWAK_HMAC_SECRET=your_hmac_secret
+```
+
+Confirm the setup:
+
+```bash
+twak auth status
+```
+
+> **Never commit your HMAC secret to version control.** If using a `.env` file, add it to `.gitignore`.
+
+## Step 3 — Make your first request
+
+Fetch the current ETH price — no wallet required:
+
+```bash
+twak price ETH
+```
+
+Add `--json` for machine-readable output:
+
+```bash
+twak price ETH --json
+# {"token":"ETH","chain":"ethereum","priceUsd":3241.87}
+```
+
+List all supported chains:
+
+```bash
+twak chains
+```
+
+## Step 4 — Explore more commands
+
+```bash
+# ETH balance for any address (coin 60 = Ethereum)
+twak balance --address <addr> --coin 60
+
+# All token holdings for an address
+twak holdings --address <addr> --coin 60
+
+# Top 5 trending tokens right now
+twak trending --limit 5
+
+# Search for tokens by name or symbol
+twak search uniswap
+
+# Transaction history for an address
+twak history --address <addr> --chain ethereum
+
+# Security / rug-risk check for a token
+twak risk c60_t0x1f9840a85d5af5bf1d1762f925bdaddc4201f984
+
+# Create an embedded agent wallet
+twak wallet create --password <pw>
+
+# Execute a token swap
+twak swap 0.1 ETH USDC --chain ethereum
+
+# Start an MCP server for AI agent integrations
+twak serve
+```
+
+Run any command with `--help` to see all options.
+
+## Next steps
+
+- [CLI Reference](cli-reference.md) — full command reference
+- [Authentication](authentication.md) — how HMAC signing works

--- a/agent-sdk/quickstart.md
+++ b/agent-sdk/quickstart.md
@@ -18,7 +18,7 @@ The CLI exposes two aliases: `twak` and `tw-agent`.
 
 ## Step 2 — Configure credentials
 
-Get your API key and HMAC secret from the [developer portal](https://developer.trustwallet.com/dashboard/keys), then run:
+Get your API key and HMAC secret from the [developer portal](https://portal.trustwallet.com/dashboard/apps), then run:
 
 ```bash
 twak init --api-key twk_live_your_access_id \

--- a/agent-sdk/quickstart.md
+++ b/agent-sdk/quickstart.md
@@ -23,14 +23,16 @@ twak init --api-key your_access_id \
           --api-secret your_hmac_secret
 ```
 
-Credentials are stored in `~/.twak/credentials.json`.
+Credentials are stored in `~/.twak/credentials.json` (file permissions `0600`). This is the recommended approach for local development.
 
-Alternatively, export environment variables (useful in CI/CD):
+For CI/CD pipelines, use environment variables instead:
 
 ```bash
 export TWAK_ACCESS_ID=your_access_id
 export TWAK_HMAC_SECRET=your_hmac_secret
 ```
+
+> **Do not add these exports to `~/.zshrc` or `~/.bashrc`.** Use `twak init` for persistent local credentials — it stores them in a dedicated file with restricted permissions. Env vars are intended for ephemeral CI/CD environments.
 
 Confirm the setup:
 

--- a/agent-sdk/quickstart.md
+++ b/agent-sdk/quickstart.md
@@ -19,7 +19,7 @@ twak --version
 Get your API key and HMAC secret from the [developer portal](https://portal.trustwallet.com/dashboard/apps), then run:
 
 ```bash
-twak init --api-key twk_live_your_access_id \
+twak init --api-key your_access_id \
           --api-secret your_hmac_secret
 ```
 
@@ -28,7 +28,7 @@ Credentials are stored in `~/.twak/credentials.json`.
 Alternatively, export environment variables (useful in CI/CD):
 
 ```bash
-export TWAK_ACCESS_ID=twk_live_your_access_id
+export TWAK_ACCESS_ID=your_access_id
 export TWAK_HMAC_SECRET=your_hmac_secret
 ```
 

--- a/agent-sdk/quickstart.md
+++ b/agent-sdk/quickstart.md
@@ -4,15 +4,20 @@ Get from zero to your first API call in under 5 minutes using the `twak` CLI.
 
 ## Step 1 — Install the CLI
 
+Run directly without installing (recommended):
+
+```bash
+npx @trustwallet/cli --version
+```
+
+Or install globally:
+
 ```bash
 npm install -g @trustwallet/cli
-```
-
-Verify the install:
-
-```bash
 twak --version
 ```
+
+> **Permission denied?** If you get `EACCES` on macOS/Linux, either use `npx @trustwallet/cli` (no install needed), install Node via [nvm](https://github.com/nvm-sh/nvm) (avoids `/usr/local` permissions), or run `sudo npm install -g @trustwallet/cli`.
 
 ## Step 2 — Configure credentials
 

--- a/agent-sdk/quickstart.md
+++ b/agent-sdk/quickstart.md
@@ -5,7 +5,7 @@ Get from zero to your first API call in under 5 minutes using the `twak` CLI.
 ## Step 1 — Install the CLI
 
 ```bash
-npm install -g @twak/cli
+npm install -g @trustwallet/cli
 ```
 
 Verify the install:
@@ -13,8 +13,6 @@ Verify the install:
 ```bash
 twak --version
 ```
-
-The CLI exposes two aliases: `twak` and `tw-agent`.
 
 ## Step 2 — Configure credentials
 
@@ -25,7 +23,7 @@ twak init --api-key twk_live_your_access_id \
           --api-secret your_hmac_secret
 ```
 
-Credentials are stored in `~/.tw-agent/credentials.json`.
+Credentials are stored in `~/.twak/credentials.json`.
 
 Alternatively, export environment variables (useful in CI/CD):
 
@@ -54,7 +52,6 @@ Add `--json` for machine-readable output:
 
 ```bash
 twak price ETH --json
-# {"token":"ETH","chain":"ethereum","priceUsd":3241.87}
 ```
 
 List all supported chains:
@@ -72,8 +69,14 @@ twak balance --address <addr> --coin 60
 # All token holdings for an address
 twak holdings --address <addr> --coin 60
 
-# Top 5 trending tokens right now
+# Trending tokens (with optional category and sort)
 twak trending --limit 5
+twak trending --category ai
+twak trending --category memes --sort volume
+
+# Browse DApps and protocols
+twak dapps
+twak dapps --category defi
 
 # Search for tokens by name or symbol
 twak search uniswap
@@ -87,7 +90,11 @@ twak risk c60_t0x1f9840a85d5af5bf1d1762f925bdaddc4201f984
 # Create an embedded agent wallet
 twak wallet create --password <pw>
 
-# Execute a token swap
+# Portfolio with USD values across all chains
+twak wallet portfolio
+
+# Get a swap quote first, then execute
+twak swap 0.1 ETH USDC --chain ethereum --quote-only
 twak swap 0.1 ETH USDC --chain ethereum
 
 # Start an MCP server for AI agent integrations


### PR DESCRIPTION
## Summary
- Add Agent SDK docs section: overview, quickstart, CLI reference, authentication
- Update README and SUMMARY with Agent SDK navigation entries

## Test plan
- [ ] Verify GitBook renders all four new pages correctly
- [ ] Check internal links between Agent SDK pages resolve