### PR TITLE
docs: add CLI skills section with automation capabilities

### DIFF
--- a/claude-code-skills/claude-code-skills.md
+++ b/claude-code-skills/claude-code-skills.md
@@ -46,7 +46,7 @@ TWAK_HMAC_SECRET=<your-hmac-secret>
 
 ## API Skills
 
-5 skills, 14 actions total.
+5 skills, 14 actions.
 
 | Skill | Actions | Description |
 |-------|---------|-------------|
@@ -56,7 +56,24 @@ TWAK_HMAC_SECRET=<your-hmac-secret>
 | `market-data` | 3 | Token prices, trending tokens across 16+ categories |
 | `security` | 2 | Address validation and token risk analysis |
 
-## Open-Source Library Skills
+## CLI Skills
+
+The `trust-wallet-cli` skill gives agents access to `twak`, the Trust Wallet CLI for multichain wallet operations.
+
+| Skill | Actions | Description |
+|-------|---------|-------------|
+| `trust-wallet-cli` | 12 | Wallet management, balances, transfers, swaps, alerts, DCA, limit orders, ERC-20, token risk, x402 |
+
+Key capabilities:
+- **Wallet**: Create HD wallets, derive addresses for 110+ chains, export keys, keychain integration
+- **Transfers**: Send native tokens and ERC-20s with ENS support and safety limits
+- **Swaps**: Same-chain and cross-chain swaps via Amber/Rango with inline approval
+- **Alerts**: Price alerts with continuous monitoring via `twak watch`
+- **Automations**: DCA (recurring swaps) and limit orders (conditional swaps) executed by `twak watch`
+- **ERC-20**: Token approvals, allowance checks, revocations
+- **MCP Server**: `twak serve` exposes all operations as MCP tools for AI agents
+
+
 
 | Skill | Description |
 |-------|-------------|


### PR DESCRIPTION
## Summary

Add CLI Skills section to Agent Skills documentation, covering `trust-wallet-cli` skill with 12 actions:
- Wallet management, balances, transfers, swaps
- Price alerts with continuous monitoring
- DCA automations and limit orders via `twak watch`
- ERC-20 operations, token risk, x402 micropayments
- MCP server (`twak serve`) for AI agent integration

## Changes

- `claude-code-skills/claude-code-skills.md` — Add CLI Skills section between API Skills and Open-Source Library Skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)