### PR TITLE
feat: Add key-management documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Programmatic access to Trust Wallet's multichain infrastructure — balance quer
 - [Quickstart](agent-sdk/quickstart.md)
 - [CLI Reference](agent-sdk/cli-reference.md)
 - [Authentication](agent-sdk/authentication.md)
+- [Key Management](agent-sdk/key-management.md)
 
 ---
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,6 +5,7 @@
   - [Quickstart](agent-sdk/quickstart.md)
   - [CLI Reference](agent-sdk/cli-reference.md)
   - [Authentication](agent-sdk/authentication.md)
+  - [Key Management](agent-sdk/key-management.md)
 - [MCP Server](mcp/mcp.md)
 - [Agent Skills](claude-code-skills/claude-code-skills.md)
 - [Developing for Trust Wallet platform](develop-for-trust/develop-for-trust.md)

--- a/agent-sdk/agent-sdk.md
+++ b/agent-sdk/agent-sdk.md
@@ -15,6 +15,7 @@ Or install globally: `npm install -g @trustwallet/cli`
 - [Quickstart](quickstart.md) — install the CLI and make your first request in 5 minutes
 - [CLI Reference](cli-reference.md) — all commands, subcommands, and flags
 - [Authentication](authentication.md) — API keys and HMAC signing
+- [Key Management](key-management.md) — wallet keys, encryption, and signing permissions
 
 ## Developer portal
 

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -44,7 +44,7 @@ twak auth status [--json]
 ### wallet create
 
 ```bash
-twak wallet create --password <pw> [--no-keychain] [--json]
+twak wallet create --password <pw> [--no-keychain] [--skip-password-check] [--json]
 ```
 
 ### wallet address

--- a/agent-sdk/cli-reference.md
+++ b/agent-sdk/cli-reference.md
@@ -53,7 +53,7 @@ twak wallet create --password <pw> [--no-keychain] [--json]
 twak wallet address --chain <chain> [--password <pw>] [--json]
 ```
 
-Password falls back to the OS keychain or `TWAK_WALLET_PASSWORD` environment variable.
+Password falls back to the OS keychain or `TWAK_WALLET_PASSWORD` environment variable. See [Key Management](key-management.md) for full details on key storage, password resolution, and signing permissions.
 
 ### wallet addresses
 

--- a/agent-sdk/key-management.md
+++ b/agent-sdk/key-management.md
@@ -43,13 +43,13 @@ The AI model never has direct access to the mnemonic or private keys. It interac
 
 ## Password Resolution
 
-When a signing operation is requested, TWAK resolves the password using the first available source:
+When a signing operation is requested, TWAK tries each source in order and uses the first one available:
 
-| Priority | Source | Notes |
-| --- | --- | --- |
-| 1 | `--password` flag | Checked first. Visible in shell history — avoid in production. |
-| 2 | `TWAK_WALLET_PASSWORD` env var | Suitable for CI/CD and containerized environments. |
-| 3 | OS keychain | macOS Keychain, Linux Secret Service. Most secure option. |
+| Source | Notes |
+| --- | --- |
+| `--password` flag | Checked first. Visible in shell history — avoid in production. |
+| `TWAK_WALLET_PASSWORD` env var | Suitable for CI/CD and containerized environments. |
+| OS keychain | macOS Keychain, Linux Secret Service. Most secure option. |
 
 If none are available, the operation fails with an authentication error.
 

--- a/agent-sdk/key-management.md
+++ b/agent-sdk/key-management.md
@@ -1,0 +1,72 @@
+# Key Management
+
+## How Keys Are Stored
+
+TWAK generates and stores private keys locally on the host machine. Keys never leave the device — not to Trust Wallet servers, not to the AI model provider, not anywhere.
+
+When the agent wallet is initialized, a BIP39 HD wallet is generated via Trust Wallet Core. The mnemonic is encrypted immediately with AES-256-GCM, using a key derived from the user's password via PBKDF2, and written to `~/.twak/wallet.json`. The mnemonic is never stored in plaintext.
+
+**What's stored on disk (`~/.twak/wallet.json`):**
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `encryptedMnemonic` | hex string | AES-256-GCM ciphertext of the mnemonic |
+| `iv` | hex string | Random initialization vector |
+| `authTag` | hex string | GCM authentication tag (detects tampering) |
+| `salt` | hex string | Random PBKDF2 salt |
+| `createdAt` | ISO 8601 | Wallet creation timestamp |
+| `chains` | string[] | List of supported chain keys |
+
+No plaintext keys, no plaintext mnemonic, no password on disk.
+
+## What the Agent Can and Cannot Do
+
+TWAK enforces a strict boundary between read-only queries and signing operations.
+
+**Without the wallet password, the agent can:**
+
+- Query any address balance
+- Search tokens and fetch prices
+- Get swap quotes
+- Validate addresses and check token risk
+- View transaction history
+
+**The following operations require the wallet password:**
+
+- Derive or reveal wallet addresses
+- Sign or send transactions
+- Execute swaps
+- Approve token spending (ERC-20)
+- Sign messages
+
+The AI model never has direct access to the mnemonic or private keys. It interacts through TWAK's action layer, which gates all signing operations behind password authentication.
+
+## Password Resolution
+
+When a signing operation is requested, TWAK resolves the password using the first available source:
+
+| Priority | Source | Notes |
+| --- | --- | --- |
+| 1 | `--password` flag | Checked first. Visible in shell history — avoid in production. |
+| 2 | `TWAK_WALLET_PASSWORD` env var | Suitable for CI/CD and containerized environments. |
+| 3 | OS keychain | macOS Keychain, Linux Secret Service. Most secure option. |
+
+If none are available, the operation fails with an authentication error.
+
+## Multi-Chain Key Derivation
+
+A single wallet derives keys for 25+ supported chains using standard BIP-44 derivation paths. All key derivation and transaction signing is handled by Trust Wallet Core:
+
+- **Ethereum and other EVM-compatible chains**: shared address across all EVM networks
+- **Bitcoin**: Legacy, SegWit, and Taproot derivation paths
+- **Solana**: Ed25519 key derivation
+- **Cosmos, TON, SUI, NEAR, Aptos, Tron**: chain-specific derivation
+
+## Password Requirements
+
+Wallet creation enforces password strength:
+
+- Minimum 8 characters
+- At least one uppercase letter, one lowercase letter, and one number
+
+These can be bypassed with `--skip-password-check` for test environments. See [CLI Reference](cli-reference.md) for the full `wallet create` command.


### PR DESCRIPTION
This pull request adds comprehensive documentation for key management in the Agent SDK and updates related references throughout the documentation. The new `key-management.md` page explains how keys are stored, password handling, signing permissions, and multi-chain support, making key security and usage much clearer for users.

**Documentation additions and improvements:**

* Added a new `agent-sdk/key-management.md` page detailing how keys are stored, password resolution, signing permissions, and multi-chain key derivation.
* Updated `SUMMARY.md` and `agent-sdk/agent-sdk.md` to include and link to the new Key Management documentation. [[1]](diffhunk://#diff-4f74b24c8cd7466c1c46dc972d8e284ed47091160afda95a432cc000f2eceb4aR8) [[2]](diffhunk://#diff-3775b3be4ac572d7504b5f2eb10916be60ee2d7c5434d49ed364fd23c9b10892R18)
* Enhanced the password documentation in `agent-sdk/cli-reference.md` to reference the new Key Management page for full details.